### PR TITLE
chore: revert "chore: consolidate mieru port configuration (#2277)"

### DIFF
--- a/adapter/outbound/mieru_test.go
+++ b/adapter/outbound/mieru_test.go
@@ -1,51 +1,22 @@
 package outbound
 
-import (
-	"reflect"
-	"testing"
-
-	mieruclient "github.com/enfein/mieru/v3/apis/client"
-	mierupb "github.com/enfein/mieru/v3/pkg/appctl/appctlpb"
-	"google.golang.org/protobuf/proto"
-)
+import "testing"
 
 func TestNewMieru(t *testing.T) {
-	transportProtocol := mierupb.TransportProtocol_TCP.Enum()
 	testCases := []struct {
 		option       MieruOption
 		wantBaseAddr string
-		wantConfig   *mieruclient.ClientConfig
 	}{
 		{
 			option: MieruOption{
 				Name:      "test",
 				Server:    "1.2.3.4",
-				Port:      "10000",
+				Port:      10000,
 				Transport: "TCP",
 				UserName:  "test",
 				Password:  "test",
 			},
 			wantBaseAddr: "1.2.3.4:10000",
-			wantConfig: &mieruclient.ClientConfig{
-				Profile: &mierupb.ClientProfile{
-					ProfileName: proto.String("test"),
-					User: &mierupb.User{
-						Name:     proto.String("test"),
-						Password: proto.String("test"),
-					},
-					Servers: []*mierupb.ServerEndpoint{
-						{
-							IpAddress: proto.String("1.2.3.4"),
-							PortBindings: []*mierupb.PortBinding{
-								{
-									Port:     proto.Int32(10000),
-									Protocol: transportProtocol,
-								},
-							},
-						},
-					},
-				},
-			},
 		},
 		{
 			option: MieruOption{
@@ -57,211 +28,27 @@ func TestNewMieru(t *testing.T) {
 				Password:  "test",
 			},
 			wantBaseAddr: "[2001:db8::1]:10001",
-			wantConfig: &mieruclient.ClientConfig{
-				Profile: &mierupb.ClientProfile{
-					ProfileName: proto.String("test"),
-					User: &mierupb.User{
-						Name:     proto.String("test"),
-						Password: proto.String("test"),
-					},
-					Servers: []*mierupb.ServerEndpoint{
-						{
-							IpAddress: proto.String("2001:db8::1"),
-							PortBindings: []*mierupb.PortBinding{
-								{
-									PortRange: proto.String("10001-10002"),
-									Protocol:  transportProtocol,
-								},
-							},
-						},
-					},
-				},
-			},
 		},
 		{
 			option: MieruOption{
 				Name:      "test",
 				Server:    "example.com",
-				Port:      "10003",
+				Port:      10003,
 				Transport: "TCP",
 				UserName:  "test",
 				Password:  "test",
 			},
 			wantBaseAddr: "example.com:10003",
-			wantConfig: &mieruclient.ClientConfig{
-				Profile: &mierupb.ClientProfile{
-					ProfileName: proto.String("test"),
-					User: &mierupb.User{
-						Name:     proto.String("test"),
-						Password: proto.String("test"),
-					},
-					Servers: []*mierupb.ServerEndpoint{
-						{
-							DomainName: proto.String("example.com"),
-							PortBindings: []*mierupb.PortBinding{
-								{
-									Port:     proto.Int32(10003),
-									Protocol: transportProtocol,
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			option: MieruOption{
-				Name:      "test",
-				Server:    "example.com",
-				Port:      "10004,10005",
-				Transport: "TCP",
-				UserName:  "test",
-				Password:  "test",
-			},
-			wantBaseAddr: "example.com:10004",
-			wantConfig: &mieruclient.ClientConfig{
-				Profile: &mierupb.ClientProfile{
-					ProfileName: proto.String("test"),
-					User: &mierupb.User{
-						Name:     proto.String("test"),
-						Password: proto.String("test"),
-					},
-					Servers: []*mierupb.ServerEndpoint{
-						{
-							DomainName: proto.String("example.com"),
-							PortBindings: []*mierupb.PortBinding{
-								{
-									Port:     proto.Int32(10004),
-									Protocol: transportProtocol,
-								},
-								{
-									Port:     proto.Int32(10005),
-									Protocol: transportProtocol,
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			option: MieruOption{
-				Name:      "test",
-				Server:    "example.com",
-				Port:      "10006-10007,11000",
-				Transport: "TCP",
-				UserName:  "test",
-				Password:  "test",
-			},
-			wantBaseAddr: "example.com:10006",
-			wantConfig: &mieruclient.ClientConfig{
-				Profile: &mierupb.ClientProfile{
-					ProfileName: proto.String("test"),
-					User: &mierupb.User{
-						Name:     proto.String("test"),
-						Password: proto.String("test"),
-					},
-					Servers: []*mierupb.ServerEndpoint{
-						{
-							DomainName: proto.String("example.com"),
-							PortBindings: []*mierupb.PortBinding{
-								{
-									PortRange: proto.String("10006-10007"),
-									Protocol:  transportProtocol,
-								},
-								{
-									Port:     proto.Int32(11000),
-									Protocol: transportProtocol,
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			option: MieruOption{
-				Name:      "test",
-				Server:    "example.com",
-				Port:      "10008",
-				PortRange: "10009-10010",
-				Transport: "TCP",
-				UserName:  "test",
-				Password:  "test",
-			},
-			wantBaseAddr: "example.com:10008",
-			wantConfig: &mieruclient.ClientConfig{
-				Profile: &mierupb.ClientProfile{
-					ProfileName: proto.String("test"),
-					User: &mierupb.User{
-						Name:     proto.String("test"),
-						Password: proto.String("test"),
-					},
-					Servers: []*mierupb.ServerEndpoint{
-						{
-							DomainName: proto.String("example.com"),
-							PortBindings: []*mierupb.PortBinding{
-								{
-									Port:     proto.Int32(10008),
-									Protocol: transportProtocol,
-								},
-								{
-									PortRange: proto.String("10009-10010"),
-									Protocol:  transportProtocol,
-								},
-							},
-						},
-					},
-				},
-			},
 		},
 	}
 
 	for _, testCase := range testCases {
 		mieru, err := NewMieru(testCase.option)
 		if err != nil {
-			t.Fatal(err)
+			t.Error(err)
 		}
-		config, err := mieru.client.Load()
-		if err != nil {
-			t.Fatal(err)
-		}
-		config.Dialer = nil
 		if mieru.addr != testCase.wantBaseAddr {
 			t.Errorf("got addr %q, want %q", mieru.addr, testCase.wantBaseAddr)
-		}
-		if !reflect.DeepEqual(config, testCase.wantConfig) {
-			t.Errorf("got config %+v, want %+v", config, testCase.wantConfig)
-		}
-	}
-}
-
-func TestNewMieruError(t *testing.T) {
-	testCases := []MieruOption{
-		{
-			Name:      "test",
-			Server:    "example.com",
-			Port:      "invalid",
-			PortRange: "invalid",
-			Transport: "TCP",
-			UserName:  "test",
-			Password:  "test",
-		},
-		{
-			Name:      "test",
-			Server:    "example.com",
-			Port:      "",
-			PortRange: "",
-			Transport: "TCP",
-			UserName:  "test",
-			Password:  "test",
-		},
-	}
-
-	for _, option := range testCases {
-		_, err := NewMieru(option)
-		if err == nil {
-			t.Errorf("expected error for option %+v, but got nil", option)
 		}
 	}
 }
@@ -276,7 +63,6 @@ func TestBeginAndEndPortFromPortRange(t *testing.T) {
 		{"1-10", 1, 10, false},
 		{"1000-2000", 1000, 2000, false},
 		{"65535-65535", 65535, 65535, false},
-		{"2000-1000", 0, 0, true},
 		{"1", 0, 0, true},
 		{"1-", 0, 0, true},
 		{"-10", 0, 0, true},

--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -1024,8 +1024,8 @@ proxies: # socks5
   - name: mieru
     type: mieru
     server: 1.2.3.4
-    port: 2999 # 支持使用 ports 格式，例如 2999,3999 或 2999-3010,3950,3995-3999
-    # port-range: 2090-2099 # 已废弃，请使用 port
+    port: 2999
+    # port-range: 2090-2099 #（不可同时填写 port 和 port-range）
     transport: TCP # 只支持 TCP
     udp: true # 支持 UDP over TCP
     username: user


### PR DESCRIPTION
The `port` field should not be allowed to be set to non-int values, as this would break some downstream assumptions that the option is an int.

This reverts commit 1b1f95aa9cb4810c971dd13ad57dd2b76ba1ad2f.